### PR TITLE
chore: add grouped Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Managed by scripts/rollout_dependabot_config.py
+# Minor + patch updates group into one weekly PR per ecosystem;
+# major bumps open individually. GitHub Actions are grouped wholesale.
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      pip:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Grouped Dependabot config

Adds `.github/dependabot.yml` to keep dependencies current while keeping PR volume low: **minor + patch updates group into one weekly PR** per ecosystem, and **major bumps open individually** so each potentially breaking change is reviewed on its own. GitHub Actions are grouped wholesale.

Detected ecosystems:
- `pip` — /

_Generated by `scripts/rollout_dependabot_config.py`._
